### PR TITLE
Different prop types options for defaults

### DIFF
--- a/src/AnnotationCreation.js
+++ b/src/AnnotationCreation.js
@@ -449,7 +449,7 @@ AnnotationCreation.propTypes = {
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
-      defaults: PropTypes.objectOf(PropTypes.string),
+      defaults: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.bool, PropTypes.func, PropTypes.number, PropTypes.string])),
     }),
   }).isRequired,
   id: PropTypes.string.isRequired,


### PR DESCRIPTION
Currently, the default properties of annotations include booleans ("closed"), functions ("updateGeometry"), numbers ("strokeWidth") and strings (e.g. "activeTool"). This PR changes the AnnotationCreation prop types to not raise a warning when one of these is overwritten.